### PR TITLE
Adjust layout to wrap fully for all font configurations. Fix API incompat

### DIFF
--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -47,13 +47,12 @@
         <TextView
             android:id="@+id/textView"
             android:layout_width="0dp"
-            android:layout_height="0dp"
+            android:layout_height="wrap_content"
             android:layout_marginStart="@dimen/camera_view_height"
             android:gravity="center_vertical"
             android:textAlignment="gravity"
-            android:autoSizeTextType="uniform"
-            app:layout_constraintHeight_percent="0.08"
             android:ellipsize="marquee"
+            android:textSize="24sp"
             android:textStyle="bold"
             app:layout_constraintTop_toBottomOf="@id/graphTextureView"
             app:layout_constraintEnd_toEndOf="parent"
@@ -73,7 +72,7 @@
             android:fillViewport="true">
             <LinearLayout
                 android:layout_width="match_parent"
-                android:layout_height="match_parent">
+                android:layout_height="wrap_content">
                 <EditText
                     android:id="@+id/editText"
                     android:layout_width="match_parent"


### PR DESCRIPTION
Some minor tweaks to your PR: https://github.com/berdosi/HeartBeat/pull/29/

This resolves
* API incompat with < API 26
* Proper wrapping for title and scrollview with all fonts (before very small portion is still overlapping like the ')' symbol